### PR TITLE
add gemini models for browser use

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -6,6 +6,7 @@ class ModelProvider(str, Enum):
     OPENAI = "openai"
     ANTHROPIC = "anthropic"
     ANTHROPIC_COMPUTER_USE = "anthropic_computer_use"
+    GEMINI = "gemini"
     # OPENROUTER = "openrouter"
     # GOOGLE = "google"
 
@@ -76,5 +77,6 @@ class ModelConfig:
             ModelProvider.OPENAI: "gpt-4o-mini",
             ModelProvider.ANTHROPIC: "claude-3-5-sonnet-latest",
             ModelProvider.ANTHROPIC_COMPUTER_USE: "claude-3-5-sonnet-20241022",
+            ModelProvider.GEMINI: "gemini-2.0-flash",
         }
         return default_models.get(provider) or ValueError("Unsupported provider.")

--- a/api/plugins/__init__.py
+++ b/api/plugins/__init__.py
@@ -97,6 +97,13 @@ AGENT_CONFIGS = {
                 "provider": ModelProvider.ANTHROPIC.value,
                 "models": ["claude-3-5-sonnet-20241022", "claude-3-opus-20240229", "claude-3-sonnet-20240229", "claude-3-haiku-20240307"],
             },
+            {
+                "provider": ModelProvider.GEMINI.value,
+                "models": [
+                    "gemini-2.0-flash",
+                    "gemini-1.5-pro"
+                ],
+            },
         ],
         "model_settings": {
             "max_tokens": {

--- a/api/providers.py
+++ b/api/providers.py
@@ -10,6 +10,7 @@ from langchain_anthropic.chat_models import convert_to_anthropic_tool
 from functools import cached_property
 import anthropic
 import os
+from langchain_google_genai import ChatGoogleGenerativeAI
 
 
 class BetaChatAnthropic(ChatAnthropic):
@@ -80,6 +81,16 @@ def create_llm(config: ModelConfig) -> BaseChatModel | Client:
             temperature=config.temperature,
             anthropic_api_key=(
                 os.getenv("ANTHROPIC_API_KEY") if not config.api_key else config.api_key
+            ),
+            **config.extra_params,
+        )
+    elif config.provider == ModelProvider.GEMINI:
+        return ChatGoogleGenerativeAI(
+            model=config.model_name or "gemini-2.0-flash",
+            temperature=config.temperature,
+            max_output_tokens=config.max_tokens,
+            google_api_key=(
+                os.getenv("GOOGLE_API_KEY") if not config.api_key else config.api_key
             ),
             **config.extra_params,
         )


### PR DESCRIPTION
This pull request introduces support for the new `GEMINI` model provider in the API. The changes include adding the `GEMINI` provider to the list of available model providers, updating the default models, and configuring the settings and provider logic to handle the new provider.

Key changes include:

### Model Provider Updates:
* Added `GEMINI` to `ModelProvider` enum in `api/models.py`.
* Updated the `default_model` function to include the default model for `GEMINI`.

### Configuration Updates:
* Added configuration for `GEMINI` provider in `SettingConfig` in `api/plugins/__init__.py`.

### Provider Logic:
* Imported `ChatGoogleGenerativeAI` in `api/providers.py` to support `GEMINI`.
* Updated the `create_llm` function to handle `GEMINI` provider logic.