### PR TITLE
fix: dont allow ollama in prod

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ListIcon, Search, SearchIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { AuthModal } from "@/components/ui/AuthModal";
 import { ChatInput } from "@/components/ui/ChatInput";
+
+import { useToast } from "@/hooks/use-toast";
+
+import { isLocalhost } from "@/lib/utils";
 
 import { useChatContext } from "./contexts/ChatContext";
 import { useSettings } from "./contexts/SettingsContext";
@@ -18,6 +21,7 @@ export default function Home() {
   const { resetSession } = useSteelContext();
   const { setInitialMessage, clearInitialState } = useChatContext();
   const { currentSettings, updateSettings } = useSettings();
+  const { toast } = useToast();
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -85,10 +89,20 @@ export default function Home() {
     try {
       setLoading(true);
       resetSession();
-      // Check if we have the API key
+      // Check if we have the API key or if Ollama is selected locally
       if (!checkApiKey()) {
-        pendingQueryRef.current = query;
-        setShowApiKeyModal(true);
+        if (currentSettings?.selectedProvider === "ollama" && !isLocalhost()) {
+          toast({
+            title: "Cannot use Ollama",
+            className:
+              "text-[var(--gray-12)] border border-[var(--red-11)] bg-[var(--red-2)] text-sm",
+            description:
+              "Please select a different model provider or run the app locally to use Ollama.",
+          });
+        } else {
+          pendingQueryRef.current = query;
+          setShowApiKeyModal(true);
+        }
         return;
       }
       proceedToChat(query);
@@ -153,8 +167,18 @@ export default function Home() {
                 if (!loading) {
                   resetSession();
                   if (!checkApiKey()) {
-                    pendingQueryRef.current = text;
-                    setShowApiKeyModal(true);
+                    if (currentSettings?.selectedProvider === "ollama" && !isLocalhost()) {
+                      toast({
+                        title: "Cannot use Ollama",
+                        className:
+                          "text-[var(--gray-12)] border border-[var(--red-11)] bg-[var(--red-2)] text-sm",
+                        description:
+                          "Please select a different model provider or run the app locally to use Ollama.",
+                      });
+                    } else {
+                      pendingQueryRef.current = text;
+                      setShowApiKeyModal(true);
+                    }
                     return;
                   }
                   proceedToChat(text);
@@ -190,8 +214,18 @@ export default function Home() {
                 if (!loading) {
                   resetSession();
                   if (!checkApiKey()) {
-                    pendingQueryRef.current = text;
-                    setShowApiKeyModal(true);
+                    if (currentSettings?.selectedProvider === "ollama" && !isLocalhost()) {
+                      toast({
+                        title: "Cannot use Ollama",
+                        className:
+                          "text-[var(--gray-12)] border border-[var(--red-11)] bg-[var(--red-2)] text-sm",
+                        description:
+                          "Please select a different model provider or run the app locally to use Ollama.",
+                      });
+                    } else {
+                      pendingQueryRef.current = text;
+                      setShowApiKeyModal(true);
+                    }
                     return;
                   }
                   proceedToChat(text);
@@ -226,8 +260,18 @@ export default function Home() {
                 if (!loading) {
                   resetSession();
                   if (!checkApiKey()) {
-                    pendingQueryRef.current = text;
-                    setShowApiKeyModal(true);
+                    if (currentSettings?.selectedProvider === "ollama" && !isLocalhost()) {
+                      toast({
+                        title: "Cannot use Ollama",
+                        className:
+                          "text-[var(--gray-12)] border border-[var(--red-11)] bg-[var(--red-2)] text-sm",
+                        description:
+                          "Please select a different model provider or run the app locally to use Ollama.",
+                      });
+                    } else {
+                      pendingQueryRef.current = text;
+                      setShowApiKeyModal(true);
+                    }
                     return;
                   }
                   proceedToChat(text);

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const isLocalhost = () => {
+  if (typeof window === "undefined") return false;
+  const hostname = window.location.hostname;
+  return hostname === "localhost" || hostname === "127.0.0.1";
+};


### PR DESCRIPTION
This pull request includes several changes to the `app/page.tsx` and `components/ui/SettingsDrawer.tsx` files to add support for detecting if the application is running locally and to handle the usage of the Ollama model provider accordingly.

### Enhancements to Local Environment Detection and Ollama Integration:

* [`app/page.tsx`](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L4-R14): Added the `useToast` and `isLocalhost` imports and integrated a toast notification to alert users if they attempt to use the Ollama model provider without running the app locally. 
* [`components/ui/SettingsDrawer.tsx`](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R28-R31): Added the `useToast` and `isLocalhost` imports, and modified the settings logic to prevent selecting Ollama as a model provider if the app is not running locally. This includes updating the provider and model selection logic, adding appropriate toast notifications, and providing detailed setup instructions for running Ollama locally. 
### Utility Function Addition:

* [`lib/utils.ts`](diffhunk://#diff-98e56006aa8453a29bc2b8bc8e6f718b3f17ba66470f3a52a5dc5bd643482e70R7-R12): Added a new utility function `isLocalhost` to detect if the application is running on a local environment.