### PR TITLE
feat: add gpt-4.5

### DIFF
--- a/api/plugins/__init__.py
+++ b/api/plugins/__init__.py
@@ -91,7 +91,7 @@ AGENT_CONFIGS = {
         "supported_models": [
             {
                 "provider": ModelProvider.OPENAI.value,
-                "models": ["gpt-4o", "gpt-4o-mini", "o1"],
+                "models": ["gpt-4.5-preview", "gpt-4o", "gpt-4o-mini", "o1"],
             },
             {
                 "provider": ModelProvider.ANTHROPIC.value,

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -743,6 +743,7 @@ export default function ChatPage() {
         provider={currentSettings?.selectedProvider || ""}
         isOpen={showApiKeyModal}
         onSubmit={handleApiKeySubmit}
+        onClose={() => setShowApiKeyModal(false)}
       />
     </>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -305,6 +305,7 @@ export default function Home() {
         provider={currentSettings?.selectedProvider || ""}
         isOpen={showApiKeyModal}
         onSubmit={handleApiKeySubmit}
+        onClose={() => setShowApiKeyModal(false)}
       />
     </main>
   );

--- a/components/ui/AuthModal.tsx
+++ b/components/ui/AuthModal.tsx
@@ -18,9 +18,10 @@ interface AuthModalProps {
   provider: string;
   isOpen: boolean;
   onSubmit: (key: string) => void;
+  onClose?: () => void;
 }
 
-export function AuthModal({ provider, isOpen, onSubmit }: AuthModalProps) {
+export function AuthModal({ provider, isOpen, onSubmit, onClose }: AuthModalProps) {
   const [apiKey, setApiKey] = useState("");
   const [error, setError] = useState("");
 
@@ -35,7 +36,14 @@ export function AuthModal({ provider, isOpen, onSubmit }: AuthModalProps) {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={() => {}}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!open && onClose) {
+          onClose();
+        }
+      }}
+    >
       <DialogContent
         className={cn(
           "flex w-[400px] shrink-0 flex-col",

--- a/components/ui/SettingsDrawer.tsx
+++ b/components/ui/SettingsDrawer.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Info, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 
+import { AuthModal } from "@/components/ui/AuthModal";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -190,6 +191,8 @@ function SettingInput({
 function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
   const { currentSettings, updateSettings } = useSettings();
   const [apiKey, setApiKey] = useState("");
+  const [showApiKeyModal, setShowApiKeyModal] = useState(false);
+  const [pendingModelChange, setPendingModelChange] = useState<string | null>(null);
   const router = useRouter();
   const { clearInitialState } = useChatContext();
   const { resetSession } = useSteelContext();
@@ -239,14 +242,23 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
       (m: SupportedModel) => m.provider === currentSettings.selectedProvider
     );
 
+    // Only reset the model if the current provider doesn't support it
     if (
       providerModels &&
       providerModels.models.length > 0 &&
-      !providerModels.models.includes(currentSettings.selectedModel)
+      !providerModels.models.includes(currentSettings.selectedModel) &&
+      currentSettings.selectedProvider === providerModels.provider
     ) {
+      // Don't auto-switch to GPT-4.5-preview if no API key
+      const defaultModel =
+        providerModels.models[0] === "gpt-4.5-preview" &&
+        !currentSettings.providerApiKeys?.[currentSettings.selectedProvider]
+          ? providerModels.models[1] // Use the next available model
+          : providerModels.models[0];
+
       updateSettings({
         ...currentSettings,
-        selectedModel: providerModels.models[0],
+        selectedModel: defaultModel,
       });
     }
   }
@@ -271,6 +283,28 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
         },
       });
     }
+  };
+
+  const handleApiKeySubmit = (key: string) => {
+    if (!currentSettings) return;
+
+    const currentKeys = currentSettings.providerApiKeys || {};
+    const updatedSettings = {
+      ...currentSettings,
+      providerApiKeys: {
+        ...currentKeys,
+        [currentSettings.selectedProvider]: key,
+      },
+    };
+
+    // If there was a pending model change, apply it now
+    if (pendingModelChange) {
+      updatedSettings.selectedModel = pendingModelChange;
+      setPendingModelChange(null);
+    }
+
+    updateSettings(updatedSettings);
+    setShowApiKeyModal(false);
   };
 
   if (!currentSettings?.selectedAgent) {
@@ -413,10 +447,29 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
                       (m: SupportedModel) => m.provider === value
                     );
                     if (providerModels && providerModels.models.length > 0) {
+                      // Keep the current model if it's available in the new provider's list
+                      let newModel = providerModels.models.includes(currentSettings.selectedModel)
+                        ? currentSettings.selectedModel
+                        : providerModels.models[0];
+
+                      // If switching to GPT-4.5-preview but no API key, show modal
+                      if (
+                        newModel === "gpt-4.5-preview" &&
+                        !currentSettings.providerApiKeys?.[value]
+                      ) {
+                        setPendingModelChange(newModel);
+                        updateSettings({
+                          ...currentSettings,
+                          selectedProvider: value,
+                        });
+                        setShowApiKeyModal(true);
+                        return;
+                      }
+
                       updateSettings({
                         ...currentSettings,
                         selectedProvider: value,
-                        selectedModel: providerModels.models[0],
+                        selectedModel: newModel,
                       });
                     }
                   }}
@@ -450,6 +503,17 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
                       });
                       return;
                     }
+
+                    // Check if trying to use GPT-4.5-preview without an API key
+                    if (
+                      value === "gpt-4.5-preview" &&
+                      !currentSettings.providerApiKeys?.[currentSettings.selectedProvider]
+                    ) {
+                      setPendingModelChange(value);
+                      setShowApiKeyModal(true);
+                      return;
+                    }
+
                     updateSettings({
                       ...currentSettings,
                       selectedModel: value,
@@ -598,7 +662,7 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
                     </p>
                     <p className="mb-2 text-sm text-[--gray-11]">
                       2. Install Ollama from{" "}
-                      <span className="text-[--blue-11] cursor-not-allowed">ollama.com</span>
+                      <span className="cursor-not-allowed text-[--blue-11]">ollama.com</span>
                     </p>
                     <p className="mb-2 text-sm text-[--gray-11]">
                       3. Run Ollama locally with the model of your choice:
@@ -608,7 +672,7 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
                     </p>
                     <p className="text-sm text-[--gray-11]">
                       Visit{" "}
-                      <span className="text-[--blue-11] cursor-not-allowed">
+                      <span className="cursor-not-allowed text-[--blue-11]">
                         our GitHub repository
                       </span>{" "}
                       for detailed setup instructions.
@@ -752,6 +816,17 @@ function SettingsContent({ closeSettings }: { closeSettings: () => void }) {
           </div>
         </div>
       </div>
+
+      {/* API Key Modal */}
+      <AuthModal
+        provider={currentSettings?.selectedProvider || ""}
+        isOpen={showApiKeyModal}
+        onSubmit={handleApiKeySubmit}
+        onClose={() => {
+          setShowApiKeyModal(false);
+          setPendingModelChange(null); // Clear any pending model change
+        }}
+      />
     </SheetContent>
   );
 }


### PR DESCRIPTION
This pull request includes several changes to enhance the handling of API keys and model selection in the settings and chat pages. The most important changes include adding support for the new model "gpt-4.5-preview", modifying the `AuthModal` component to handle closing events, and updating the settings logic to prompt for an API key when selecting certain models.

Enhancements to model support and settings logic:

* [`api/plugins/__init__.py`](diffhunk://#diff-95fa6ee9ad07e380fb47c4e5668200397d41be1c1a34b7d0c78cb5d5b033fc35L94-R94): Added support for the "gpt-4.5-preview" model in the `SettingConfig` class.
* [`components/ui/SettingsDrawer.tsx`](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R194-R195): Updated the `SettingsContent` function to handle the selection of the "gpt-4.5-preview" model and prompt for an API key if necessary. This includes changes to reset the model if the current provider doesn't support it and handle pending model changes. [[1]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R194-R195) [[2]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R245-R261) [[3]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R288-R309) [[4]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R450-R472) [[5]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R506-R516) [[6]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R819-R829)

Modifications to `AuthModal` component:

* [`components/ui/AuthModal.tsx`](diffhunk://#diff-49a60a6b9dd2ed81e98fd12a2d7ba082655c959a28a6cd2717e703ffaaecadfeR21-R24): Added an optional `onClose` prop to the `AuthModal` component and updated the `Dialog` component to call `onClose` when the modal is closed. [[1]](diffhunk://#diff-49a60a6b9dd2ed81e98fd12a2d7ba082655c959a28a6cd2717e703ffaaecadfeR21-R24) [[2]](diffhunk://#diff-49a60a6b9dd2ed81e98fd12a2d7ba082655c959a28a6cd2717e703ffaaecadfeL38-R46)
* [`components/ui/SettingsDrawer.tsx`](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R7): Imported the `AuthModal` component and utilized it to handle API key submissions and modal closing events. [[1]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R7) [[2]](diffhunk://#diff-eb9139f45c65c288036232a316bb205077c40265ddc3dd292b941c4a442e9078R819-R829)

Updates to chat and home pages:

* `app/chat/page.tsx` and `app/page.tsx`: Added the `onClose` prop to the `AuthModal` component to ensure the modal can be closed properly. [[1]](diffhunk://#diff-3d983e27ffe99b5b66d07453aca5a99d3f4c9fd88fc2f28e185c64f225ff2420R746) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R308)