### PR TITLE
nit: add env variable to example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,1 +1,2 @@
 API_URL=http://localhost:8000
+STEEL_CONNECT_URL=wss://connect.steel.dev


### PR DESCRIPTION
This pull request includes a small change to the `.env.local.example` file. The change adds a new environment variable `STEEL_CONNECT_URL` to the configuration.

* [`.env.local.example`](diffhunk://#diff-51db1e9260201708554a6d042039c4cd3366a090e6d2c3c59f281b22740dc7d6R2): Added `STEEL_CONNECT_URL` with the value `wss://connect.steel.dev` to the environment configuration.