### PR TITLE
feat: add pause-resume debugging functionality

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,2 @@
+# This is intentionally empty but ensures the api directory is a proper package.
+# This setup allows for relative imports between modules and helps prevent circular imports. 

--- a/api/plugins/__init__.py
+++ b/api/plugins/__init__.py
@@ -31,6 +31,7 @@ class SettingType(Enum):
     FLOAT = "float"
     TEXT = "text"
     TEXTAREA = "textarea"
+    BOOLEAN = "boolean"
 
 
 class SettingConfig(TypedDict):
@@ -153,6 +154,17 @@ AGENT_CONFIGS = {
                 "min": 10,
                 "max": 125,
                 "description": "Max number of steps to take",
+            },
+            "debug_mode": {
+                "type": SettingType.BOOLEAN.value,
+                "default": False,
+                "description": "Enable debug pause on specific URLs",
+            },
+            "debug_page_urls": {
+                "type": SettingType.TEXTAREA.value,
+                "default": "",
+                "maxLength": 1000,
+                "description": "URLs to pause agent execution (comma-separated)",
             },
         },
     },

--- a/api/plugins/browser_use/__init__.py
+++ b/api/plugins/browser_use/__init__.py
@@ -1,3 +1,3 @@
-from .agent import browser_use_agent
+from .agent import browser_use_agent, agent_manager
 
-__all__ = ["browser_use_agent"]
+__all__ = ["browser_use_agent", "agent_manager"]

--- a/api/utils/prompt.py
+++ b/api/utils/prompt.py
@@ -17,6 +17,7 @@ class ClientMessage(BaseModel):
     content: str | List[str | Mapping[str, Any]]
     experimental_attachments: Optional[List[ClientAttachment]] = None
     toolInvocations: Optional[List[ToolInvocation]] = None
+    resume_agent: Optional[bool] = None
 
 
 def convert_to_chat_messages(messages: List[ClientMessage]):

--- a/api/utils/types.py
+++ b/api/utils/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from typing import List, Mapping, Any, Optional
 
 
@@ -14,7 +14,20 @@ class AgentSettings(BaseModel):
     system_prompt: Optional[str] = None
     num_images_to_keep: Optional[int] = Field(default=10, ge=1, le=50)
     wait_time_between_steps: Optional[int] = Field(default=1, ge=0, le=10)
-    steps: Optional[int] = None
+    debug_mode: Optional[bool] = False
+    debug_page_urls: Optional[List[str]] = []
+    
+    @validator('debug_page_urls', pre=True)
+    def parse_debug_urls(cls, value):
+        # If it's already a list, return it
+        if isinstance(value, list):
+            return value
+        # If it's a string, split on commas and strip whitespace
+        if isinstance(value, str):
+            if not value.strip():
+                return []
+            return [url.strip() for url in value.split(',') if url.strip()]
+        return value
 
 
 class ModelSettings(BaseModel):

--- a/app/contexts/SettingsContext.tsx
+++ b/app/contexts/SettingsContext.tsx
@@ -18,7 +18,9 @@ export interface AgentSettings {
   num_images_to_keep?: number;
   wait_time_between_steps?: number;
   steps?: number;
-  [key: string]: string | number | undefined;
+  debug_mode?: boolean;
+  debug_page_urls?: string[];
+  [key: string]: string | number | boolean | string[] | undefined;
 }
 
 export interface SurfSettings {

--- a/components/ui/SettingsDrawer.tsx
+++ b/components/ui/SettingsDrawer.tsx
@@ -5,6 +5,7 @@ import { Info, Settings } from "lucide-react";
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -120,6 +121,15 @@ function SettingInput({
           </TooltipProvider>
         )}
       </div>
+
+      {config.type === "boolean" && (
+        <Checkbox
+          id={`checkbox-${settingKey}`}
+          checked={currentValue === true}
+          onChange={e => onChange(e.target.checked)}
+          label={currentValue ? "Enabled" : "Disabled"}
+        />
+      )}
 
       {config.type === "float" && (
         <div className="flex flex-col gap-2">

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, label, ...props }, ref) => {
+    return (
+      <div className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          className={cn(
+            "h-4 w-4 rounded border border-[--gray-6] bg-transparent text-[--gray-12]",
+            "focus:outline-none focus:ring-2 focus:ring-[--gray-8] focus:ring-offset-2",
+            "checked:bg-[--gray-12] checked:border-[--gray-12]",
+            "cursor-pointer",
+            className
+          )}
+          ref={ref}
+          {...props}
+        />
+        {label && (
+          <label
+            htmlFor={props.id}
+            className="text-sm font-medium text-[--gray-11] cursor-pointer"
+          >
+            {label}
+          </label>
+        )}
+      </div>
+    );
+  }
+);
+
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox }; 

--- a/types/agents.ts
+++ b/types/agents.ts
@@ -1,6 +1,6 @@
 export interface SettingConfig {
-  type: "integer" | "float" | "text" | "textarea";
-  default: number | string;
+  type: "integer" | "float" | "text" | "textarea" | "boolean";
+  default: number | string | boolean;
   min?: number;
   max?: number;
   step?: number;


### PR DESCRIPTION
https://discord.com/channels/1285696350117167226/1354237789230600322/1354237789230600322

current issue: I am pausing the agent inside register_new_step_callback, but when I resume it, the agent runs a new similar step instead of executing the paused step. How can I ensure the paused step is executed?

My main goal is to pause the agent and modify the element index if the LLM is about to use an incorrect element.

[agent] 📍 Step 4
INFO     [agent] 👍 Eval: Success - navigated to google.com
INFO     [agent] 🧠 Memory:
INFO     [agent] 🎯 Next goal: Input microsoft into the search field
INFO     [agent] 🛠️  Action 1/1: {"input_text":{"index":7,"text":"microsoft"}}
INFO     [agent] 🔄 pausing Agent 
INFO     [agent] ▶️ Agent resuming
INFO     [agent] 📍 Step 5
INFO     [agent] 👍 Eval: Success - navigated to google.com
INFO     [agent] 🧠 Memory:
INFO     [agent] 🎯 Next goal: Search for microsoft
INFO     [agent] 🛠️  Action 1/1: {"input_text":{"index":7,"text":"microsoft"}}
INFO     [agent] 🔄 pausing Agent
INFO     [agent] ▶️ Agent resuming
INFO     [agent] 📍 Step 6
INFO     [agent] 👍 Eval: Success - navigated to google.com
INFO     [agent] 🧠 Memory:
INFO     [agent] 🎯 Next goal: Search microsoft
INFO     [agent] 🛠️  Action 1/1: {"input_text":{"index":7,"text":"microsoft"}}
INFO     [agent] 🔄 pausing Agent